### PR TITLE
chore: ensure commonjs setup and cookie parser typing

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "server",
   "version": "1.0.0",
-  "type": "module",
+  "type": "commonjs",
   "main": "dist/index.js",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { type RequestHandler } from "express";
 import cors from "cors";
 import cookieParser from "cookie-parser";
 import authRouter from "./routes/auth";
@@ -9,7 +9,7 @@ const PORT = parseInt(process.env.PORT || "3001", 10);
 const ORIGIN = process.env.CORS_ORIGIN || "http://localhost:5173";
 app.use(cors({ origin: ORIGIN, credentials: true }));
 app.use(express.json());
-app.use(cookieParser());
+app.use(cookieParser() as unknown as RequestHandler);
 app.get("/healthz", (_req, res) => res.json({ ok: true }));
 app.use("/auth", authRouter);
 app.use("/me", meRouter);

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -7,8 +7,11 @@
 
     // Environment Settings
     // See also https://aka.ms/tsconfig/module
-    "module": "nodenext",
+    "module": "commonjs",
+    "moduleResolution": "node",
     "target": "esnext",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "types": [],
     // For nodejs:
     // "lib": ["esnext"],
@@ -35,7 +38,6 @@
     // Recommended Options
     "strict": true,
     "jsx": "react-jsx",
-    "verbatimModuleSyntax": true,
     "isolatedModules": true,
     "noUncheckedSideEffectImports": true,
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
- explicitly resolve CommonJS modules with Node resolution
- cast cookie-parser middleware to Express's RequestHandler

## Testing
- `npm run build -w server`
- `npm run dev -w server`
- `npm test -w server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689baafaa55883278e85774f0281cf6c