### PR TITLE
Ensure server dev script uses local tsconfig

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "type": "commonjs",
   "main": "dist/index.js",
   "scripts": {
-    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "dev": "ts-node-dev --respawn --transpile-only --project tsconfig.json src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "prisma:generate": "prisma generate",


### PR DESCRIPTION
## Summary
- ensure ts-node-dev uses the server tsconfig when running the API

## Testing
- `npm run dev -w server`
- `npm run dev`
- `npm run build -w server`


------
https://chatgpt.com/codex/tasks/task_e_689bca55caa08327b16f542a0292f910