### PR TITLE
fix: ensure rollup present for client workspace

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@vitejs/plugin-react": "^4.2.1",
+    "rollup": "^4.46.2",
     "typescript": "^5.5.4",
     "vite": "^5.2.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,15 +24,16 @@
         "react-router-dom": "^6.23.0",
         "svguitar": "^1.3.3"
       },
-      "devDependencies": {
-        "@types/react": "^18.2.66",
-        "@types/react-dom": "^18.2.22",
-        "@vitejs/plugin-react": "^4.2.1",
-        "typescript": "^5.5.4",
-        "vite": "^5.2.0"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
+        "devDependencies": {
+          "@types/react": "^18.2.66",
+          "@types/react-dom": "^18.2.22",
+          "@vitejs/plugin-react": "^4.2.1",
+          "rollup": "^4.46.2",
+          "typescript": "^5.5.4",
+          "vite": "^5.2.0"
+        }
+      },
+      "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",


### PR DESCRIPTION
## Summary
- add rollup as explicit dev dependency in client workspace to avoid invalid package config errors
- update lockfile accordingly

## Testing
- `npm run build` *(fails: Could not resolve entry module "index.html")*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bf429bcb48327a757ca5bffa20ae8