### PR TITLE
Install dependencies and generate Prisma client before dev

### DIFF
--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -15,6 +15,12 @@ else
   docker start "$DB_CONTAINER_NAME"
 fi
 
+# install dependencies for all workspaces
+npm install >/dev/null
+
+# ensure prisma client is generated
+npm run prisma:generate -w server >/dev/null
+
 pushd server >/dev/null
 if [ -f .env ]; then
   npx prisma db push >/dev/null


### PR DESCRIPTION
## Summary
- ensure run-local.sh installs workspace dependencies before starting
- generate Prisma client to avoid runtime errors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bfade53888327a53d3a48797c7fef