### PR TITLE
chore: automate dev setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "workspaces": ["client", "server"],
   "scripts": {
-    "dev": "npm run dev -w client & npm run dev -w server",
+    "dev": "bash scripts/run-local.sh",
+    "dev:workspaces": "npm run dev -w client & npm run dev -w server",
     "build": "npm -w client run build && npm -w server run build",
     "format": "prettier -w .",
     "lint": "echo \"(add your linter of choice)\"",

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -15,10 +15,15 @@ else
   docker start "$DB_CONTAINER_NAME"
 fi
 
-pushd server >/dev/null
-if [ -f .env ]; then
-  npx prisma db push >/dev/null
-fi
-popd >/dev/null
+# install dependencies for all workspaces
+npm install >/dev/null
 
-npm run dev
+# ensure prisma client is generated
+npm run prisma:generate -w server >/dev/null
+
+# apply database migrations when env file is present
+if [ -f server/.env ]; then
+  npm run prisma:migrate -w server >/dev/null
+fi
+
+npm run dev:workspaces


### PR DESCRIPTION
## Summary
- run dev environment through `run-local.sh` to auto-install deps, generate Prisma client, and run migrations
- add `dev:workspaces` helper script for client/server concurrent start

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bfade53888327a53d3a48797c7fef