### PR TITLE
Support extended chord symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Guitar Chord Generator
+
 Single-page app that generates four-chord progressions with chord names and SVGuitar diagrams.
+Supports arbitrary chord symbols including inversions, 7ths and extensions.
+
 - Client: Vite + React + TypeScript, SVGuitar, html2canvas, jsPDF
 - Server: Express + TypeScript, Prisma + Postgres, JWT auth (httpOnly cookie)
 - Features: login, save progressions, export PNG/PDF

--- a/client/src/lib/chords.ts
+++ b/client/src/lib/chords.ts
@@ -1,37 +1,86 @@
 export type ChordName = string;
 
-export const KEYS = ["C","G","D","A","E","B","F#","Db","Ab","Eb","Bb","F"];
-export const ROMAN_TEMPLATES = ["I-vi-IV-V","I-V-vi-IV","ii-V-I-I"];
+export const KEYS = [
+  "C",
+  "G",
+  "D",
+  "A",
+  "E",
+  "B",
+  "F#",
+  "Db",
+  "Ab",
+  "Eb",
+  "Bb",
+  "F",
+];
+export const ROMAN_TEMPLATES = [
+  "I-vi-IV-V",
+  "I-V-vi-IV",
+  "ii-V-I-I",
+  "Imaj7-vi7-ii7-V7",
+];
 
-const CHROMA = ["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"];
-const DEGREE_MAP: Record<string,{ semis:number; minor:boolean }> = {
-  I: { semis:0, minor:false },
-  ii: { semis:2, minor:true },
-  iii:{ semis:4, minor:true },
-  IV:{ semis:5, minor:false },
-  V: { semis:7, minor:false },
-  vi:{ semis:9, minor:true },
-  vii:{ semis:11, minor:true }
+const CHROMA = [
+  "C",
+  "C#",
+  "D",
+  "D#",
+  "E",
+  "F",
+  "F#",
+  "G",
+  "G#",
+  "A",
+  "A#",
+  "B",
+];
+const DEGREE_MAP: Record<string, { semis: number; minor: boolean }> = {
+  I: { semis: 0, minor: false },
+  ii: { semis: 2, minor: true },
+  iii: { semis: 4, minor: true },
+  IV: { semis: 5, minor: false },
+  V: { semis: 7, minor: false },
+  vi: { semis: 9, minor: true },
+  vii: { semis: 11, minor: true },
 };
 
-function normalizeKey(k:string){
-  return k.replace("Db","C#").replace("Eb","D#").replace("Gb","F#").replace("Ab","G#").replace("Bb","A#");
+function normalizeKey(k: string) {
+  return k
+    .replace("Db", "C#")
+    .replace("Eb", "D#")
+    .replace("Gb", "F#")
+    .replace("Ab", "G#")
+    .replace("Bb", "A#");
 }
 
-function transpose(keyIndex:number, semis:number){
-  return CHROMA[(keyIndex + semis + 12)%12];
+function transpose(keyIndex: number, semis: number) {
+  return CHROMA[(keyIndex + semis + 12) % 12];
 }
 
-export function generateProgression(key:string, roman:string): ChordName[]{
+function resolveSuffix(suffix: string, keyIndex: number) {
+  return suffix.replace(/\/[ivIV]+/g, (m) => {
+    const deg = m.slice(1);
+    const info = DEGREE_MAP[deg];
+    if (!info) return m;
+    return "/" + transpose(keyIndex, info.semis);
+  });
+}
+
+export function generateProgression(key: string, roman: string): ChordName[] {
   const chosenKey = KEYS.includes(key) ? key : KEYS[0];
   const norm = normalizeKey(chosenKey);
   const keyIndex = CHROMA.indexOf(norm);
   const degrees = roman.split("-");
-  return degrees.map(d=>{
-    const info = DEGREE_MAP[d];
-    if(!info) return "";
+  return degrees.map((d) => {
+    const match = d.match(/^([ivIV]+)(.*)$/);
+    if (!match) return "";
+    const [, deg, rawSuffix] = match;
+    const info = DEGREE_MAP[deg];
+    if (!info) return "";
     const root = transpose(keyIndex, info.semis);
-    const suffix = info.minor ? "m" : "";
-    return `${root}${suffix}`;
+    const quality = info.minor ? "m" : "";
+    const suffix = resolveSuffix(rawSuffix, keyIndex);
+    return `${root}${quality}${suffix}`;
   });
 }

--- a/client/src/lib/diagrams.ts
+++ b/client/src/lib/diagrams.ts
@@ -1,43 +1,133 @@
 import { Chord, OPEN, SILENT } from "svguitar";
 
 const OPEN_CHORDS: Record<string, Chord> = {
-  C: { fingers: [
-    [1, OPEN], [2,1], [3,OPEN], [4,2], [5,3], [6,SILENT]
-  ], barres: [] },
-  D: { fingers: [
-    [1,2],[2,3],[3,2],[4,OPEN],[5,SILENT],[6,SILENT]
-  ], barres: [] },
-  E: { fingers: [
-    [1,OPEN],[2,OPEN],[3,1],[4,2],[5,2],[6,OPEN]
-  ], barres: [] },
-  G: { fingers: [
-    [1,3],[2,OPEN],[3,OPEN],[4,OPEN],[5,2],[6,3]
-  ], barres: [] },
-  A: { fingers: [
-    [1,OPEN],[2,2],[3,2],[4,2],[5,OPEN],[6,SILENT]
-  ], barres: [] },
-  Am: { fingers: [
-    [1,OPEN],[2,1],[3,2],[4,2],[5,OPEN],[6,SILENT]
-  ], barres: [] },
-  Dm: { fingers: [
-    [1,1],[2,3],[3,2],[4,OPEN],[5,SILENT],[6,SILENT]
-  ], barres: [] },
-  Em: { fingers: [
-    [1,OPEN],[2,OPEN],[3,OPEN],[4,2],[5,2],[6,OPEN]
-  ], barres: [] },
-  F: { fingers: [
-    [1,1],[2,1],[3,2],[4,3],[5,3],[6,1]
-  ], barres: [{ fromString:6, toString:1, fret:1, text:"1" }] }
+  C: {
+    fingers: [
+      [1, OPEN],
+      [2, 1],
+      [3, OPEN],
+      [4, 2],
+      [5, 3],
+      [6, SILENT],
+    ],
+    barres: [],
+  },
+  D: {
+    fingers: [
+      [1, 2],
+      [2, 3],
+      [3, 2],
+      [4, OPEN],
+      [5, SILENT],
+      [6, SILENT],
+    ],
+    barres: [],
+  },
+  E: {
+    fingers: [
+      [1, OPEN],
+      [2, OPEN],
+      [3, 1],
+      [4, 2],
+      [5, 2],
+      [6, OPEN],
+    ],
+    barres: [],
+  },
+  G: {
+    fingers: [
+      [1, 3],
+      [2, OPEN],
+      [3, OPEN],
+      [4, OPEN],
+      [5, 2],
+      [6, 3],
+    ],
+    barres: [],
+  },
+  A: {
+    fingers: [
+      [1, OPEN],
+      [2, 2],
+      [3, 2],
+      [4, 2],
+      [5, OPEN],
+      [6, SILENT],
+    ],
+    barres: [],
+  },
+  Am: {
+    fingers: [
+      [1, OPEN],
+      [2, 1],
+      [3, 2],
+      [4, 2],
+      [5, OPEN],
+      [6, SILENT],
+    ],
+    barres: [],
+  },
+  Dm: {
+    fingers: [
+      [1, 1],
+      [2, 3],
+      [3, 2],
+      [4, OPEN],
+      [5, SILENT],
+      [6, SILENT],
+    ],
+    barres: [],
+  },
+  Em: {
+    fingers: [
+      [1, OPEN],
+      [2, OPEN],
+      [3, OPEN],
+      [4, 2],
+      [5, 2],
+      [6, OPEN],
+    ],
+    barres: [],
+  },
+  F: {
+    fingers: [
+      [1, 1],
+      [2, 1],
+      [3, 2],
+      [4, 3],
+      [5, 3],
+      [6, 1],
+    ],
+    barres: [{ fromString: 6, toString: 1, fret: 1, text: "1" }],
+  },
 };
 
-const CHROMA = ["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"];
+const CHROMA = [
+  "C",
+  "C#",
+  "D",
+  "D#",
+  "E",
+  "F",
+  "F#",
+  "G",
+  "G#",
+  "A",
+  "A#",
+  "B",
+];
 
 export function getChordDiagram(name: string): Chord | null {
-  if (OPEN_CHORDS[name]) return OPEN_CHORDS[name];
-  const isMinor = name.endsWith("m");
-  const root = name.replace(/m$/, "")
-    .replace("Db","C#").replace("Eb","D#")
-    .replace("Gb","F#").replace("Ab","G#").replace("Bb","A#");
+  const match = name.match(/^([A-G](?:#|b)?)(m?)/);
+  if (!match) return null;
+  const [, rawRoot, minorFlag] = match;
+  const root = rawRoot
+    .replace("Db", "C#")
+    .replace("Eb", "D#")
+    .replace("Gb", "F#")
+    .replace("Ab", "G#")
+    .replace("Bb", "A#");
+  const isMinor = minorFlag === "m";
   const openName = root + (isMinor ? "m" : "");
   if (OPEN_CHORDS[openName]) return OPEN_CHORDS[openName];
   const rootIndex = CHROMA.indexOf(root);
@@ -47,9 +137,12 @@ export function getChordDiagram(name: string): Chord | null {
   const base = OPEN_CHORDS[isMinor ? "Em" : "E"];
   const fingers = base.fingers.map(([string, fret]) => {
     if (fret === SILENT) return [string, SILENT] as [number, typeof SILENT];
-    if (fret === OPEN) return [string, offset === 0 ? OPEN : offset] as [number, number];
+    if (fret === OPEN)
+      return [string, offset === 0 ? OPEN : offset] as [number, number];
     return [string, (fret as number) + offset] as [number, number];
   });
-  const barres = offset ? [{ fromString:6, toString:1, fret:offset, text:"1" }] : [];
+  const barres = offset
+    ? [{ fromString: 6, toString: 1, fret: offset, text: "1" }]
+    : [];
   return { fingers, barres, position: offset > 1 ? offset : 1 };
 }


### PR DESCRIPTION
## Summary
- allow roman numeral chords to include suffixes like 7ths, inversions and extensions
- parse complex chord names when rendering diagrams
- document extended chord support

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cb2585bd88327bfaa543fc145c794