### PR TITLE
feat: expand progression generation

### DIFF
--- a/client/src/lib/chords.ts
+++ b/client/src/lib/chords.ts
@@ -14,12 +14,6 @@ export const KEYS = [
   "Bb",
   "F",
 ];
-export const ROMAN_TEMPLATES = [
-  "I-vi-IV-V",
-  "I-V-vi-IV",
-  "ii-V-I-I",
-  "Imaj7-vi7-ii7-V7",
-];
 
 const CHROMA = [
   "C",
@@ -35,15 +29,41 @@ const CHROMA = [
   "A#",
   "B",
 ];
-const DEGREE_MAP: Record<string, { semis: number; minor: boolean }> = {
-  I: { semis: 0, minor: false },
-  ii: { semis: 2, minor: true },
-  iii: { semis: 4, minor: true },
-  IV: { semis: 5, minor: false },
-  V: { semis: 7, minor: false },
-  vi: { semis: 9, minor: true },
-  vii: { semis: 11, minor: true },
+
+// pool of degree chains including diatonic, borrowed and secondary/tertiary dominants
+const DEGREE_POOL = [
+  "I",
+  "ii",
+  "iii",
+  "IV",
+  "V",
+  "vi",
+  "vii",
+  "bII",
+  "bIII",
+  "bVI",
+  "bVII",
+  "V/ii",
+  "V/iii",
+  "V/IV",
+  "V/V",
+  "V/vi",
+  "V/V/ii",
+  "V/V/V",
+];
+
+const BASE_MAP: Record<string, number> = {
+  I: 0,
+  II: 2,
+  III: 4,
+  IV: 5,
+  V: 7,
+  VI: 9,
+  VII: 11,
 };
+
+const MAJOR_SUFFIXES = ["", "7", "maj7", "9", "11", "13"];
+const MINOR_SUFFIXES = ["", "7", "9", "11", "13"];
 
 function normalizeKey(k: string) {
   return k
@@ -55,32 +75,69 @@ function normalizeKey(k: string) {
 }
 
 function transpose(keyIndex: number, semis: number) {
-  return CHROMA[(keyIndex + semis + 12) % 12];
+  return CHROMA[(keyIndex + semis + 1200) % 12];
 }
 
-function resolveSuffix(suffix: string, keyIndex: number) {
-  return suffix.replace(/\/[ivIV]+/g, (m) => {
-    const deg = m.slice(1);
-    const info = DEGREE_MAP[deg];
-    if (!info) return m;
-    return "/" + transpose(keyIndex, info.semis);
-  });
+function getSingleDegree(token: string) {
+  const m = token.match(/^([b#]*)([ivIV]+)$/);
+  if (!m) return null;
+  const [, acc, deg] = m;
+  const base = deg.toUpperCase();
+  const semisBase = BASE_MAP[base];
+  if (semisBase === undefined) return null;
+  let semis = semisBase;
+  for (const ch of acc) semis += ch === "b" ? -1 : 1;
+  const minor = deg === deg.toLowerCase();
+  return { semis, minor };
 }
 
-export function generateProgression(key: string, roman: string): ChordName[] {
+function parseDegreeChain(chain: string) {
+  const parts = chain.split("/");
+  let info = getSingleDegree(parts.pop() as string);
+  if (!info) return null;
+  let semis = info.semis;
+  let minor = info.minor;
+  while (parts.length) {
+    const p = getSingleDegree(parts.pop() as string);
+    if (!p) return null;
+    semis += p.semis;
+    minor = p.minor;
+  }
+  semis = ((semis % 12) + 12) % 12;
+  return { semis, minor };
+}
+
+export function generateProgression(key: string, length = 4): { chords: ChordName[]; roman: string } {
   const chosenKey = KEYS.includes(key) ? key : KEYS[0];
   const norm = normalizeKey(chosenKey);
   const keyIndex = CHROMA.indexOf(norm);
-  const degrees = roman.split("-");
-  return degrees.map((d) => {
-    const match = d.match(/^([ivIV]+)(.*)$/);
-    if (!match) return "";
-    const [, deg, rawSuffix] = match;
-    const info = DEGREE_MAP[deg];
-    if (!info) return "";
+  const romans: string[] = [];
+  const chords: string[] = [];
+  for (let i = 0; i < length; i++) {
+    const base = DEGREE_POOL[Math.floor(Math.random() * DEGREE_POOL.length)];
+    const info = parseDegreeChain(base);
+    if (!info) {
+      romans.push(base);
+      chords.push("");
+      continue;
+    }
+    const suffixes = info.minor ? MINOR_SUFFIXES : MAJOR_SUFFIXES;
+    const suffix = suffixes[Math.floor(Math.random() * suffixes.length)];
     const root = transpose(keyIndex, info.semis);
-    const quality = info.minor ? "m" : "";
-    const suffix = resolveSuffix(rawSuffix, keyIndex);
-    return `${root}${quality}${suffix}`;
-  });
+    let chord = `${root}${info.minor ? "m" : ""}${suffix}`;
+    let roman = base + suffix;
+    const invChance = Math.random();
+    if (invChance < 0.33) {
+      const third = transpose(keyIndex, info.semis + (info.minor ? 3 : 4));
+      chord += `/${third}`;
+      roman += `/${third}`;
+    } else if (invChance < 0.66) {
+      const fifth = transpose(keyIndex, info.semis + 7);
+      chord += `/${fifth}`;
+      roman += `/${fifth}`;
+    }
+    romans.push(roman);
+    chords.push(chord);
+  }
+  return { chords, roman: romans.join("-") };
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { generateProgression, KEYS, ROMAN_TEMPLATES } from "../lib/chords";
+import { generateProgression, KEYS } from "../lib/chords";
 import ChordDiagram from "../components/ChordDiagram";
 import html2canvas from "html2canvas";
 import { jsPDF } from "jspdf";
@@ -7,16 +7,16 @@ import { api } from "../lib/api";
 export default function Home({ user }: { user: any | null }) {
   const [name, setName] = useState("My Progression");
   const [key, setKey] = useState(KEYS[0]);
-  const randomTemplate = () => ROMAN_TEMPLATES[Math.floor(Math.random() * ROMAN_TEMPLATES.length)];
-  const [roman, setRoman] = useState(randomTemplate());
-  const [chords, setChords] = useState<string[]>(generateProgression(key, roman));
+  const initial = generateProgression(key);
+  const [roman, setRoman] = useState(initial.roman);
+  const [chords, setChords] = useState<string[]>(initial.chords);
   const [saved, setSaved] = useState<any[]>([]);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const regenerate = () => {
-    const newRoman = randomTemplate();
-    setRoman(newRoman);
-    setChords(generateProgression(key, newRoman));
+    const next = generateProgression(key);
+    setRoman(next.roman);
+    setChords(next.chords);
   };
   const editChord = (i:number, value:string) => {
     const arr = [...chords]; arr[i] = value; setChords(arr);
@@ -25,6 +25,11 @@ export default function Home({ user }: { user: any | null }) {
     const res = await api.get("/progressions"); setSaved(res.data);
   };
   useEffect(()=>{ if(user) loadSaves(); },[user]);
+  useEffect(()=>{
+    const next = generateProgression(key);
+    setRoman(next.roman);
+    setChords(next.chords);
+  },[key]);
 
   const save = async () => {
     await api.post("/progressions", { name, key, roman, chords });
@@ -68,7 +73,7 @@ export default function Home({ user }: { user: any | null }) {
           <ul>
             {saved.map((p: any) => (
               <li key={p.id}>
-                <button onClick={()=>{setName(p.name||"");setKey(p.key||KEYS[0]);setRoman(p.roman||ROMAN_TEMPLATES[0]);setChords(p.chords);}}>{p.name || p.id}</button>
+                <button onClick={()=>{setName(p.name||"");setKey(p.key||KEYS[0]);setRoman(p.roman||"");setChords(p.chords);}}>{p.name || p.id}</button>
                 <button onClick={()=>{api.delete(`/progressions/${p.id}`);loadSaves();}}>Delete</button>
               </li>
             ))}


### PR DESCRIPTION
## Summary
- randomize chord degrees from diatonic, borrowed, and secondary/tertiary dominants with optional inversions
- use new progression generator on the home page and regenerate on key changes

## Testing
- `npm test` (fails: Missing script)
- `npm run build -w client`


------
https://chatgpt.com/codex/tasks/task_e_689cc02340448327ac1d0bacf0d9f399