### PR TITLE
Support slash chord bass notes in chord diagrams

### DIFF
--- a/client/src/components/ChordDiagram.tsx
+++ b/client/src/components/ChordDiagram.tsx
@@ -8,11 +8,12 @@ export default function ChordDiagram({ chordName, id }: { chordName: string; id:
     if (!el) return;
     el.innerHTML = "";
     const chart = new SVGuitarChord(el);
-    const diagram = getChordDiagram(chordName);
+    const name = chordName.trim();
+    const diagram = getChordDiagram(name);
     if (diagram) {
-      chart.chord({ ...diagram, title: chordName }).draw();
+      chart.chord({ ...diagram, title: name }).draw();
     } else {
-      chart.chord({ fingers: [], barres: [], title: chordName }).draw();
+      chart.chord({ fingers: [], barres: [], title: name }).draw();
     }
   }, [chordName, id]);
   return <div id={id} style={{ width: 180, height: 220 }} />;


### PR DESCRIPTION
## Summary
- parse optional bass note in `getChordDiagram` and include it in fingering search
- allow `searchFingering` to enforce a specified bass as the lowest note
- ensure chord renderer passes full chord name for inversions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm -w client run build`
- `npm -w server run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ce2f68d648327a3a6b5671c4f7d7b