### PR TITLE
Handle whitespace when parsing slash chords

### DIFF
--- a/client/src/lib/diagrams.ts
+++ b/client/src/lib/diagrams.ts
@@ -273,7 +273,9 @@ function searchFingering(notes: number[], bass: number | null): Chord | null {
 }
 
 export function getChordDiagram(name: string): Chord | null {
-  const [main, bassToken] = name.split("/");
+  const [rawMain, rawBass] = name.split("/");
+  const main = rawMain.trim();
+  const bassToken = rawBass ? rawBass.trim() : null;
   const match = main.match(/^([A-G](?:#|b)?)(.*)$/);
   if (!match) return null;
   const [, rawRoot, suffix] = match;


### PR DESCRIPTION
## Summary
- Trim main and bass components before parsing so slash chords like `C / E` resolve correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d3d349cc883279a733a4b98003282