### PR TITLE
Handle invalid roots in chord diagrams

### DIFF
--- a/client/src/lib/diagrams.test.ts
+++ b/client/src/lib/diagrams.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { normalizeRoot, getChordDiagram } from './diagrams';
+
+test('normalizeRoot handles enharmonic equivalents', () => {
+  assert.strictEqual(normalizeRoot('Cb'), 'B');
+  assert.strictEqual(normalizeRoot('Fb'), 'E');
+  assert.strictEqual(normalizeRoot('E#'), 'F');
+  assert.strictEqual(normalizeRoot('B#'), 'C');
+});
+
+test('normalizeRoot returns null for invalid inputs', () => {
+  assert.strictEqual(normalizeRoot('H'), null);
+  assert.strictEqual(normalizeRoot('Q#'), null);
+});
+
+test('getChordDiagram surfaces error for invalid root', () => {
+  const original = console.error;
+  const messages: string[] = [];
+  console.error = (msg?: any) => {
+    messages.push(String(msg));
+  };
+  const result = getChordDiagram('Hmaj7');
+  console.error = original;
+  assert.strictEqual(result, null);
+  assert.ok(messages.some((m) => m.includes('Invalid chord name')));
+});

--- a/client/src/lib/diagrams.ts
+++ b/client/src/lib/diagrams.ts
@@ -165,7 +165,7 @@ const CHORD_FORMULAS: Record<string, number[]> = {
   maj13: [0, 4, 7, 11, 14, 17, 21],
 };
 
-function normalizeRoot(raw: string): string {
+export function normalizeRoot(raw: string): string | null {
   const base = raw
     .replace("Cb", "B")
     .replace("Fb", "E")
@@ -174,7 +174,7 @@ function normalizeRoot(raw: string): string {
   if (CHROMA_SHARP.includes(base) || CHROMA_FLAT.includes(base)) {
     return base;
   }
-  return base;
+  return null;
 }
 
 function getFormula(suffix: string): number[] | null {
@@ -293,9 +293,16 @@ export function getChordDiagram(name: string): Chord | null {
   const main = rawMain.trim();
   const bassToken = rawBass ? rawBass.trim() : null;
   const match = main.match(/^([A-G](?:#|b)?)(.*)$/);
-  if (!match) return null;
+  if (!match) {
+    console.error(`Invalid chord name: ${name}`);
+    return null;
+  }
   const [, rawRoot, suffix] = match;
   const root = normalizeRoot(rawRoot);
+  if (!root) {
+    console.error(`Invalid root note: ${rawRoot}`);
+    return null;
+  }
   const openName = root + suffix;
   if (!bassToken && OPEN_CHORDS[openName]) return OPEN_CHORDS[openName];
   const rootIndex =
@@ -307,11 +314,15 @@ export function getChordDiagram(name: string): Chord | null {
   const bassIndex = bassToken
     ? (() => {
         const norm = normalizeRoot(bassToken);
+        if (!norm) {
+          console.error(`Invalid bass note: ${bassToken}`);
+          return null;
+        }
         const sharpIdx = CHROMA_SHARP.indexOf(norm);
         return sharpIdx >= 0 ? sharpIdx : CHROMA_FLAT.indexOf(norm);
       })()
     : null;
-  if (bassToken && bassIndex === -1) return null;
+  if (bassToken && bassIndex === null) return null;
   const formulas = [formula];
   if (formula.length > 4) {
     formulas.push(...reduceFormula(formula));


### PR DESCRIPTION
## Summary
- export `normalizeRoot` and return `null` for unknown notes
- log errors in `getChordDiagram` when chord name or bass note is invalid
- add tests for enharmonic and invalid inputs

## Testing
- `node --test dist-test/diagrams.test.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e012a71b88327940d23ac05eb25e5