### PR TITLE
Validate chords and highlight invalid input

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "axios": "^1.7.2",
@@ -23,6 +24,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "rollup": "^4.46.2",
     "typescript": "^5.5.4",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/client/src/pages/Home.test.tsx
+++ b/client/src/pages/Home.test.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { vi, test, expect } from "vitest";
+import Home from "./Home";
+
+vi.mock("../components/ChordDiagram", () => ({
+  default: ({ chordName }: { chordName: string }) => <div>{chordName}</div>,
+}));
+
+test("shows error for invalid chord input", () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  act(() => {
+    ReactDOM.render(<Home user={null} />, container);
+  });
+  const input = container.querySelector("input") as HTMLInputElement;
+  act(() => {
+    input.value = "H#";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  expect(container.textContent).toContain("Invalid chord");
+});

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -4,12 +4,16 @@ import ChordDiagram from "../components/ChordDiagram";
 import html2canvas from "html2canvas";
 import { jsPDF } from "jspdf";
 import { api } from "../lib/api";
+import { getChordDiagram } from "../lib/diagrams";
 export default function Home({ user }: { user: any | null }) {
   const [name, setName] = useState("My Progression");
   const [key, setKey] = useState(KEYS[0]);
   const initial = generateProgression(key);
   const [roman, setRoman] = useState(initial.roman);
   const [chords, setChords] = useState<string[]>(initial.chords);
+  const [invalid, setInvalid] = useState<boolean[]>(
+    initial.chords.map(() => false),
+  );
   const [saved, setSaved] = useState<any[]>([]);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -17,19 +21,30 @@ export default function Home({ user }: { user: any | null }) {
     const next = generateProgression(key);
     setRoman(next.roman);
     setChords(next.chords);
+    setInvalid(next.chords.map(() => false));
   };
-  const editChord = (i:number, value:string) => {
-    const arr = [...chords]; arr[i] = value; setChords(arr);
+  const editChord = (i: number, value: string) => {
+    const arr = [...chords];
+    arr[i] = value;
+    const isValid = !!getChordDiagram(value.trim());
+    const inv = [...invalid];
+    inv[i] = !isValid;
+    setChords(arr);
+    setInvalid(inv);
   };
   const loadSaves = async () => {
-    const res = await api.get("/progressions"); setSaved(res.data);
+    const res = await api.get("/progressions");
+    setSaved(res.data);
   };
-  useEffect(()=>{ if(user) loadSaves(); },[user]);
-  useEffect(()=>{
+  useEffect(() => {
+    if (user) loadSaves();
+  }, [user]);
+  useEffect(() => {
     const next = generateProgression(key);
     setRoman(next.roman);
     setChords(next.chords);
-  },[key]);
+    setInvalid(next.chords.map(() => false));
+  }, [key]);
 
   const save = async () => {
     await api.post("/progressions", { name, key, roman, chords });
@@ -37,31 +52,73 @@ export default function Home({ user }: { user: any | null }) {
     alert("Saved");
   };
   const exportPNG = async () => {
-    if (!containerRef.current) return; const canvas = await html2canvas(containerRef.current);
-    const a = document.createElement("a"); a.href = canvas.toDataURL("image/png"); a.download = "progression.png"; a.click();
+    if (!containerRef.current) return;
+    const canvas = await html2canvas(containerRef.current);
+    const a = document.createElement("a");
+    a.href = canvas.toDataURL("image/png");
+    a.download = "progression.png";
+    a.click();
   };
   const exportPDF = async () => {
-    if (!containerRef.current) return; const canvas = await html2canvas(containerRef.current);
-    const pdf = new jsPDF({ orientation: "landscape", unit: "px", format: [canvas.width, canvas.height] });
-    pdf.addImage(canvas.toDataURL("image/png"), "PNG", 0, 0, canvas.width, canvas.height); pdf.save("progression.pdf");
+    if (!containerRef.current) return;
+    const canvas = await html2canvas(containerRef.current);
+    const pdf = new jsPDF({
+      orientation: "landscape",
+      unit: "px",
+      format: [canvas.width, canvas.height],
+    });
+    pdf.addImage(
+      canvas.toDataURL("image/png"),
+      "PNG",
+      0,
+      0,
+      canvas.width,
+      canvas.height,
+    );
+    pdf.save("progression.pdf");
   };
   return (
     <div style={{ padding: 16 }}>
       <h1>Four-Chord Generator</h1>
-      <div style={{ display: "flex", gap: 16, marginBottom: 12, flexWrap: "wrap" }}>
-        <label>Key: <select value={key} onChange={e=>setKey(e.target.value)}>{KEYS.map(k=><option key={k} value={k}>{k}</option>)}</select></label>
-        <label>Name: <input value={name} onChange={e=>setName(e.target.value)} /></label>
+      <div
+        style={{ display: "flex", gap: 16, marginBottom: 12, flexWrap: "wrap" }}
+      >
+        <label>
+          Key:{" "}
+          <select value={key} onChange={(e) => setKey(e.target.value)}>
+            {KEYS.map((k) => (
+              <option key={k} value={k}>
+                {k}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Name: <input value={name} onChange={(e) => setName(e.target.value)} />
+        </label>
         <button onClick={regenerate}>Randomize</button>
         {user && <button onClick={save}>Save</button>}
         <button onClick={exportPNG}>Export PNG</button>
         <button onClick={exportPDF}>Export PDF</button>
       </div>
       <div ref={containerRef}>
-        <h2>{name} ({key})</h2>
+        <h2>
+          {name} ({key})
+        </h2>
         <div style={{ display: "flex", gap: 16 }}>
           {chords.map((c, i) => (
             <div key={i} style={{ textAlign: "center" }}>
-              <input value={c} onChange={e=>editChord(i,e.target.value)} style={{ textAlign: "center" }} />
+              <input
+                value={c}
+                onChange={(e) => editChord(i, e.target.value)}
+                style={{
+                  textAlign: "center",
+                  borderColor: invalid[i] ? "red" : undefined,
+                }}
+              />
+              {invalid[i] && (
+                <div style={{ color: "red", fontSize: 12 }}>Invalid chord</div>
+              )}
               <ChordDiagram chordName={c} id={`chord-${i}`} />
             </div>
           ))}
@@ -73,8 +130,25 @@ export default function Home({ user }: { user: any | null }) {
           <ul>
             {saved.map((p: any) => (
               <li key={p.id}>
-                <button onClick={()=>{setName(p.name||"");setKey(p.key||KEYS[0]);setRoman(p.roman||"");setChords(p.chords);}}>{p.name || p.id}</button>
-                <button onClick={()=>{api.delete(`/progressions/${p.id}`);loadSaves();}}>Delete</button>
+                <button
+                  onClick={() => {
+                    setName(p.name || "");
+                    setKey(p.key || KEYS[0]);
+                    setRoman(p.roman || "");
+                    setChords(p.chords);
+                    setInvalid(p.chords.map(() => false));
+                  }}
+                >
+                  {p.name || p.id}
+                </button>
+                <button
+                  onClick={() => {
+                    api.delete(`/progressions/${p.id}`);
+                    loadSaves();
+                  }}
+                >
+                  Delete
+                </button>
               </li>
             ))}
           </ul>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -3,5 +3,8 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   server: { port: 5173 },
-  build: { outDir: "dist" }
+  build: { outDir: "dist" },
+  test: {
+    environment: "jsdom",
+  },
 });


### PR DESCRIPTION
## Summary
- validate edited chords against available diagrams before updating state
- show inline warning when chord input is invalid
- add failing vitest test covering invalid chord feedback

## Testing
- `npm run build -w client`
- `npm test -w client` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e012ae1948327bc5b02b0a0b1d9a1